### PR TITLE
use react-refresh in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,12 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@expo/webpack-config": "^0.17.2",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@types/react": "~18.0.26",
     "@types/react-native": "~0.71.0",
+    "react-refresh": "^0.14.0",
     "typescript": "^4.9.4",
+    "webpack-hot-middleware": "^2.25.3",
     "xnft": "latest"
   },
   "resolutions": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,18 +1,21 @@
-const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+const createExpoWebpackConfigAsync = require("@expo/webpack-config");
+const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
+
 const fs = require("fs");
 
 module.exports = async function (env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
 
-  // keep everything the same for expo start
-  if(env.mode === "development") {
+  if (env.mode === "development") {
+    config.plugins.push(new ReactRefreshWebpackPlugin());
+    // keep everything else the same for expo start
     return config;
   }
 
   config.output = {
-    globalObject: 'this',
+    globalObject: "this",
     path: __dirname + "/dist/.artifacts/",
-    filename: 'index.js',
+    filename: "index.js",
   };
 
   config.optimization.splitChunks = {
@@ -22,28 +25,32 @@ module.exports = async function (env, argv) {
   };
   config.optimization.runtimeChunk = false;
 
-
-  config.plugins = config.plugins.filter(
-    (plugin) => ["DefinePlugin", "CleanWebpackPlugin"].includes(plugin.constructor.name)
-  )
+  config.plugins = config.plugins.filter((plugin) =>
+    ["DefinePlugin", "CleanWebpackPlugin"].includes(plugin.constructor.name)
+  );
 
   config.plugins.push(
     new InlineJSPlugin({
       template: "template.html",
-      filename: "index.html"
+      filename: "index.html",
     })
   );
 
-
   // this is brittle but works for now.
-  const loaders = config.module.rules.find(rule => typeof rule.oneOf !== "undefined");
-  const urlLoader = loaders.oneOf.find((loader) => typeof loader.use === "object" && loader.use.loader && loader.use.loader.includes("url-loader"));
+  const loaders = config.module.rules.find(
+    (rule) => typeof rule.oneOf !== "undefined"
+  );
+  const urlLoader = loaders.oneOf.find(
+    (loader) =>
+      typeof loader.use === "object" &&
+      loader.use.loader &&
+      loader.use.loader.includes("url-loader")
+  );
 
   urlLoader.use.options.limit = true;
   urlLoader.test = /\.(gif|jpe?g|png|svg|css|woff2?|eot|ttf|otf)$/;
 
   return config;
-
 };
 
 // const logger = console.log.bind(console);
@@ -52,17 +59,23 @@ class InlineJSPlugin {
   constructor({ template, filename }) {
     this.options = {
       template,
-      filename
-    }
+      filename,
+    };
   }
   apply(compiler) {
-    compiler.hooks.done.tap('InlineJSPlugin', (stats) => {
+    compiler.hooks.done.tap("InlineJSPlugin", (stats) => {
       const filename = stats.compilation.outputOptions.filename;
       const path = stats.compilation.outputOptions.path;
       const asset = stats.compilation.assets[filename];
       const JSBundle = asset.children[0]._value;
-      const template = fs.readFileSync(this.options.template).toString().split("####JS####");
-      fs.writeFileSync(path + "/../" + this.options.filename, template[0] + JSBundle + template[1]);
+      const template = fs
+        .readFileSync(this.options.template)
+        .toString()
+        .split("####JS####");
+      fs.writeFileSync(
+        path + "/../" + this.options.filename,
+        template[0] + JSBundle + template[1]
+      );
     });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,6 +2407,21 @@
     chrome-trace-event "^1.0.2"
     nullthrows "^1.1.1"
 
+"@pmmmwh/react-refresh-webpack-plugin@^0.5.10":
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz#2eba163b8e7dbabb4ce3609ab5e32ab63dda3ef8"
+  integrity sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==
+  dependencies:
+    ansi-html-community "^0.0.8"
+    common-path-prefix "^3.0.0"
+    core-js-pure "^3.23.3"
+    error-stack-parser "^2.0.6"
+    find-up "^5.0.0"
+    html-entities "^2.1.0"
+    loader-utils "^2.0.4"
+    schema-utils "^3.0.0"
+    source-map "^0.7.3"
+
 "@react-native-community/cli-clean@^9.2.1":
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-9.2.1.tgz#198c5dd39c432efb5374582073065ff75d67d018"
@@ -3322,6 +3337,11 @@ ansi-fragments@^0.2.1:
     colorette "^1.0.7"
     slice-ansi "^2.0.0"
     strip-ansi "^5.0.0"
+
+ansi-html-community@0.0.8, ansi-html-community@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
+  integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
 ansi-html@0.0.7:
   version "0.0.7"
@@ -4618,6 +4638,11 @@ commander@~2.13.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
   integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
 
+common-path-prefix@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-3.0.0.tgz#7d007a7e07c58c4b4d5f433131a19141b29f11e0"
+  integrity sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -4773,6 +4798,11 @@ core-js-compat@^3.25.1:
   integrity sha512-622/KzTudvXCDLRw70iHW4KKs1aGpcRcowGWyYJr2DEBfRrd6hNJybxSWJFuZYD4ma86xhrwDDHxmDaIq4EA8A==
   dependencies:
     browserslist "^4.21.4"
+
+core-js-pure@^3.23.3:
+  version "3.27.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.27.1.tgz#ede4a6b8440585c7190062757069c01d37a19dca"
+  integrity sha512-BS2NHgwwUppfeoqOXqi08mUqS5FiZpuRuJJpKsaME7kJz0xxuk0xkhDdfMIlP/zLa80krBqss1LtD7f889heAw==
 
 core-js-pure@^3.25.1:
   version "3.26.1"
@@ -7267,6 +7297,11 @@ html-entities@^1.3.1:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.4.0.tgz#cfbd1b01d2afaf9adca1b10ae7dffab98c71d2dc"
   integrity sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==
 
+html-entities@^2.1.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.3.tgz#117d7626bece327fc8baace8868fa6f5ef856e46"
+  integrity sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==
+
 html-loader@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-1.1.0.tgz#91915f4d274caa9d46d1c3dc847cd82bfc037dbd"
@@ -8501,7 +8536,7 @@ loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^2.0.0:
+loader-utils@^2.0.0, loader-utils@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
   integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
@@ -11031,6 +11066,11 @@ react-native@0.70.5:
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
+react-refresh@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
+  integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
 react-refresh@^0.4.0:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.3.tgz#966f1750c191672e76e16c2efa569150cc73ab53"
@@ -13175,6 +13215,15 @@ webpack-dev-server@3.11.0:
     webpack-log "^2.0.0"
     ws "^6.2.1"
     yargs "^13.3.2"
+
+webpack-hot-middleware@^2.25.3:
+  version "2.25.3"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.25.3.tgz#be343ce2848022cfd854dd82820cd730998c6794"
+  integrity sha512-IK/0WAHs7MTu1tzLTjio73LjS3Ov+VvBKQmE8WPlJutgG5zT6Urgq/BbAdRrHTRpyzK0dvAvFh1Qg98akxgZpA==
+  dependencies:
+    ansi-html-community "0.0.8"
+    html-entities "^2.1.0"
+    strip-ansi "^6.0.0"
 
 webpack-log@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
fixes #11 

This uses react-refresh which should mean that `window.xnft` is still available after new changes are loaded into the xnft during development