### PR TITLE
Change xnft dependency to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@expo/webpack-config": "^0.17.2",
     "@types/react": "~18.0.26",
     "@types/react-native": "~0.71.0",
-    "xnft": ">0.2.0-latest.2873"
+    "xnft": "latest"
   },
   "resolutions": {
     "react-error-overlay": "6.0.9"


### PR DESCRIPTION
When running `yarn dev` I was seeing an error in the terminal:

```
npm ERR! could not determine executable to run

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/callum/.npm/_logs/2023-03-09T16_52_13_195Z-debug-0.log
error Command failed with exit code 1.
```

This was due to the `npx xnft --iframe http://localhost:19006` part of the dev command

The result was the "localhost refused to connect." error in simulator, caused because there is no process running on `localhost:9933`

I identified https://github.com/coral-xyz/xnft-quickstart/commit/3c1e9706d9ca132ce63cf252bff4a74959c1dedd as the cause

That commit hardcoded the `xnft` version, which seemed to be causing the issue. Changing it back to `latest` fixes the issue. The console error is gone, we see the log "listening on port 9933", and the simulator is able to connect correctly.