### PR TITLE
xnft.json is missing the contact field and causes bundle failure

### DIFF
--- a/xnft.json
+++ b/xnft.json
@@ -7,6 +7,9 @@
   "icon": {
     "md": "./assets/icon.png"
   },
+  "contact": {
+    "repository": ""
+  },
   "screenshots": [
     "./assets/screenShot.png"
   ],


### PR DESCRIPTION
This pr adds a contact field to xnft.json to enable bundling