### PR TITLE
Default didLaunch to true if already launched

### DIFF
--- a/src/hooks/xnft-hooks.tsx
+++ b/src/hooks/xnft-hooks.tsx
@@ -84,7 +84,7 @@ export function useEthereumConnection(): Connection|undefined {
 
 // Returns true if the `window.xnft` object is ready to be used.
 export function useDidLaunch() {
-  const [didConnect, setDidConnect] = useState(false);
+  const [didConnect, setDidConnect] = useState(!!window.xnft?.connection);
   useEffect(() => {
     window.addEventListener("load", () => {
       window.xnft.on("connect", () => {


### PR DESCRIPTION
I'm finding that the `useDidLaunch` hook is often incorrectly set to false, and from looking at the events being triggered it seems to be because it's already connected at the point my `xnft` is calling it, and so the default False is never being updated

This PR changes the default value to `!!window.xnft?.connection`, so if there's already a `window.xnft.connection` object when the hook is called then it'll default to True. If there's no `window.xnft` yet, or `window.xnft.connection` is undefined, then it'll default to False and rely on the existing events to update it as it currently does. 