### PR TITLE
prevent browser from automatically opening

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "expo export:web",
     "start": "yarn build && npx xnft web",
     "bundle": "yarn build && npx xnft bundle",
-    "dev": "expo start --web & npx xnft --iframe http://localhost:19006"
+    "dev": "BROWSER=none expo start --web & npx xnft --iframe http://localhost:19006"
   },
   "dependencies": {
     "@coral-xyz/common-public": "^0.2.0-latest.3375",


### PR DESCRIPTION
add `BROWSER=none` so the [better-opn](https://github.com/michaellzc/better-opn/blob/ed13333539dc81dff9eb4e7f9707b3fa2e4a80e5/src/index.js#L22-L23) dependency of `@expo/cli` doesn't auto open the browser