### PR TITLE
Fix: Fix broken link in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Quickstart repo for building your own xNFT.
 
 Once you've installed Backpack, get started building your xNFT with these steps. Note that the packages here will always use the latest, which correspond to the latest tagged build of Backpack. If you have unexepected issues, make sure your package versions match the app version.
 
-Further documentation: https://docs.xnfts.dev/getting-started/getting-started
+Further documentation: https://docs.xnfts.dev/getting-started/introduction
 
 ### Install
 


### PR DESCRIPTION
fixed broken link https://docs.xnfts.dev/getting-started/getting-started by replacing it with https://docs.xnfts.dev/getting-started/introduction