### PR TITLE
Update `xnft` version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/react": "~18.0.28",
     "@types/react-native": "~0.71.3",
     "typescript": "^4.9.5",
-    "xnft": "latest"
+    "xnft": "^0.9.3-latest.3026"
   },
   "resolutions": {
     "react-error-overlay": "6.0.11"


### PR DESCRIPTION
For some reason, yarn is pulling an old version of `xnft`, which gives the error described
[here](https://github.com/coral-xyz/xnft-quickstart/issues/44). This specifies the version so that the error goes away.